### PR TITLE
Update sign processing to update traffic signs code #17

### DIFF
--- a/.github/workflows/on_demand_trigger.yml
+++ b/.github/workflows/on_demand_trigger.yml
@@ -40,3 +40,14 @@ jobs:
       run: |
         python3 code/process_new_signs.py
       shell: sh
+    - name: Upload WFS features
+      uses: actions/upload-artifact@v3
+      with:
+        name: WFS_Input
+        path: python_output/feature_output.csv
+    - name: Upload geojson results
+      uses: actions/upload-artifact@v3
+      with:
+        name: GeoJSON_Output
+        path: python_output/geojson_output.json
+  

--- a/code/process_new_signs.py
+++ b/code/process_new_signs.py
@@ -11,8 +11,8 @@ feature_type = "awv:Verkeersborden.Vlaanderen_Borden"
 feature_file = "./python_output/feature_output.csv"
 geojson_file = "./python_output/geojson_output.json"
 process_date = get_process_date()
-maproulette_api_key = environ.get("MAPROULETTE_API_KEY")
-challenge_id = environ['CHALLENGE_ID']
+#maproulette_api_key = environ.get("MAPROULETTE_API_KEY")
+#challenge_id = environ['CHALLENGE_ID']
 
 if __name__== "__main__":
   logging.info("Processing new features after %s, updates will be published to challenge %s [API key: %s].", process_date, challenge_id, maproulette_api_key)
@@ -22,4 +22,4 @@ if __name__== "__main__":
     logging.info("No new features found.")
   else:
     save_geojson(signs_dataframe, geojson_file)
-    upload_to_maproulette(maproulette_api_key, challenge_id, geojson_file)
+    #upload_to_maproulette(maproulette_api_key, challenge_id, geojson_file)


### PR DESCRIPTION
# Description

- Removes Z from the code and adds zone to the parameters from all `bordcode` values that start with a Z
- Removes slashes from the code
- Adds zone to the parameters when the code starts with a Z
- Updated join to do a left join

# How was it tested
Tested by running the latest code locally, for example the zone signs below are now parsed properly (C43 code, speed limit, etc..)

  | id | traffic_sign_code | extra_text | traffic_sign_description | date_installed | longitude | latitude
-- | -- | -- | -- | -- | -- | -- | --
0 | 3162891 | C43 | zone,ja,C43,["400","Neen","50"], | Speed limit | 30/6/23 | 30.899.083.872.995.400 | ##########
1 | 3196863 | C43 | zone,ja,C43,["400","Neen","50"], | Speed limit | 30/6/23 | 30.978.583.625.319.600 | ##########
2 | 3204549 | C43 | zone,ja,C43,["400","Neen","50"], | Speed limit | 30/6/23 | 3.088.259.900.400.550 | ##########








</body>

</html>
